### PR TITLE
*: add tpcc/ch prepare --skip-ddl and --only-ddl parameters

### DIFF
--- a/cmd/go-tpc/ch_benchmark.go
+++ b/cmd/go-tpc/ch_benchmark.go
@@ -66,6 +66,14 @@ func registerCHBenchmark(root *cobra.Command) {
 		"tidb_index_serial_scan_concurrency",
 		1,
 		"tidb_index_serial_scan_concurrency param for analyze jobs")
+	cmdPrepare.PersistentFlags().BoolVar(&chConfig.OnlyDdl,
+		"only-ddl",
+		false,
+		"ch prepare only ddl (default false)")
+	cmdPrepare.PersistentFlags().BoolVar(&chConfig.SkipDdl,
+		"skip-ddl",
+		false,
+		"ch prepare skip ddl (default false)")
 
 	var cmdRun = &cobra.Command{
 		Use:   "run",

--- a/cmd/go-tpc/tpcc.go
+++ b/cmd/go-tpc/tpcc.go
@@ -102,6 +102,8 @@ func registerTpcc(root *cobra.Command) {
 		"generating file, separated by ','. Valid only if output is set. If this flag is not set, generate all tables by default")
 	cmdPrepare.PersistentFlags().IntVar(&tpccConfig.PrepareRetryCount, "retry-count", 50, "Retry count when errors occur")
 	cmdPrepare.PersistentFlags().DurationVar(&tpccConfig.PrepareRetryInterval, "retry-interval", 10*time.Second, "The interval for each retry")
+	cmdPrepare.PersistentFlags().BoolVar(&tpccConfig.OnlyDdl, "only-ddl", false, "TPCC prepare ddl only (default false)")
+	cmdPrepare.PersistentFlags().BoolVar(&tpccConfig.SkipDdl, "skip-ddl", false, "TPCC prepare skip ddl (default false)")
 
 	var cmdRun = &cobra.Command{
 		Use:   "run",


### PR DESCRIPTION
For ch-benchmark longevity test, we need to allow go-tpc to create ddl first and load data without creating ddl in separate steps. So I added those two parameters to skip and create only ddl.