### PR TITLE
tpch prepare support skip and only ddl

### DIFF
--- a/cmd/go-tpc/tpch.go
+++ b/cmd/go-tpc/tpch.go
@@ -132,6 +132,16 @@ func registerTpch(root *cobra.Command) {
 		20,
 		"kafka flush timeout seconds",
 	)
+	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.SkipDdl,
+		"skip-ddl",
+		false,
+		"tpch prepare skip ddl (default false)",
+	)
+	cmdPrepare.PersistentFlags().BoolVar(&tpchConfig.OnlyDdl,
+		"only-ddl",
+		false,
+		"tpch prepare only ddl (default false)",
+	)
 
 	var cmdRun = &cobra.Command{
 		Use:   "run",

--- a/tpch/workload.go
+++ b/tpch/workload.go
@@ -132,7 +132,7 @@ func (w *Workloader) Prepare(ctx context.Context, threadID int) error {
 	if threadID != 0 {
 		return nil
 	}
-	if w.cfg.OutputType != "kafka" && !w.cfg.SkipDdl{
+	if w.cfg.OutputType != "kafka" && !w.cfg.SkipDdl {
 		if err := w.createTables(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
Allow go-tpc tpch prepare to skip ddl or execute ddl only.